### PR TITLE
Add support for CRLF and CR

### DIFF
--- a/denops/@ddc-sources/dictionary.ts
+++ b/denops/@ddc-sources/dictionary.ts
@@ -53,7 +53,7 @@ export class Source extends BaseSource<Params> {
       const delimiter = content.includes("\r\n") ? "\r\n"
                       : content.includes("\r") ? "\r"
                       : "\n"
-      const texts = Deno.readTextFileSync(dictFile).split(delimiter);
+      const texts = content.split(delimiter);
       this.cache[dictFile] = {
         "mtime": mtime,
         "candidates": texts.map((word) => ({ word })),


### PR DESCRIPTION
I would like to use https://github.com/dwyl/english-words, which uses CRLF for newline.
This pull request makes the code to deal with CLRL and CR. Thanks.