### PR TITLE
Add menu

### DIFF
--- a/denops/@ddc-sources/dictionary.ts
+++ b/denops/@ddc-sources/dictionary.ts
@@ -52,7 +52,7 @@ export class Source extends BaseSource<Params> {
       const texts = Deno.readTextFileSync(dictFile).split("\n");
       this.cache[dictFile] = {
         "mtime": mtime,
-        "candidates": texts.map((word) => ({ word })),
+        "candidates": texts.map((word) => ({ word, menu: dictFile })),
       };
     }
   }


### PR DESCRIPTION
I would like to see where the word comes from. <Ctrl-X> dictioanry completion shows it.
Thus, I suggest to display the dictionary path as a menu of ddc. Thanks.