### PR TITLE
feat: extract the last word from case-styled `completeStr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ call ddc#custom#patch_global('sourceParams', {
       \ '/usr/share/dict/words',
       \ '/usr/share/dict/spanish'],
       \ 'smartCase': v:true,
+      \ 'isVolatile': v:true,
       \ }
       \ })
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ https://github.com/Shougo/ddc.vim
 For detail, please see help file.
 
 ```vim
-" you neeed to set 'dictionary' option
+" you need to set 'dictionary' option
 setlocal dictionary+=/usr/share/dict/words
 " or you can specify dictionary path using sourceParams ('dictPaths' must be list of files)
 call ddc#custom#patch_global('sourceParams', {

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ ddc source for dictionary
 
 ### denops.vim
 
-https://github.com/vim-denops/denops.vim
+<https://github.com/vim-denops/denops.vim>
 
 ### ddc.vim
 
-https://github.com/Shougo/ddc.vim
+<https://github.com/Shougo/ddc.vim>
 
 ## Configuration examples
 
@@ -21,7 +21,7 @@ For detail, please see help file.
 setlocal dictionary+=/usr/share/dict/words
 " or you can specify dictionary path using sourceParams ('dictPaths' must be list of files)
 call ddc#custom#patch_global('sourceParams', {
-      \ 'dictionary': {'dictPaths': 
+      \ 'dictionary': {'dictPaths':
       \ ['/usr/share/dict/german',
       \ '/usr/share/dict/words',
       \ '/usr/share/dict/spanish'],
@@ -39,4 +39,4 @@ call ddc#custom#patch_global('sourceOptions', {
 
 ## Original version
 
-https://github.com/deoplete-plugins/deoplete-dictionary
+<https://github.com/deoplete-plugins/deoplete-dictionary>

--- a/doc/ddc-dictionary.txt
+++ b/doc/ddc-dictionary.txt
@@ -37,10 +37,10 @@ EXAMPLES					*ddc-dictionary-examples*
 >
 	" you need to set 'dictionary' option
 	setlocal dictionary+=/usr/share/dict/words
-	" or you can specify dictionary path using sourceParams 
+	" or you can specify dictionary path using sourceParams
 	" ('dictPaths' must be list of files)
 	call ddc#custom#patch_global('sourceParams', {
-	      \ 'dictionary': {'dictPaths': 
+	      \ 'dictionary': {'dictPaths':
 	      \ ['/usr/share/dict/german',
 	      \ '/usr/share/dict/words',
 	      \ '/usr/share/dict/spanish'],

--- a/doc/ddc-dictionary.txt
+++ b/doc/ddc-dictionary.txt
@@ -45,6 +45,7 @@ EXAMPLES					*ddc-dictionary-examples*
 	      \ '/usr/share/dict/words',
 	      \ '/usr/share/dict/spanish'],
 	      \ 'smartCase': v:true,
+	      \ 'isVolatile': v:true,
 	      \ }
 	      \ })
 

--- a/doc/ddc-dictionary.txt
+++ b/doc/ddc-dictionary.txt
@@ -29,13 +29,13 @@ https://github.com/vim-denops/denops.vim
 ==============================================================================
 USAGE							*ddc-dictionary-usage*
 
-Set 'dictionary' option or set "dicitonary" sourceParams like example below.
+Set 'dictionary' option or set "dictionary" sourceParams like example below.
 
 ==============================================================================
 EXAMPLES					*ddc-dictionary-examples*
 
 >
-	" you neeed to set 'dictionary' option
+	" you need to set 'dictionary' option
 	setlocal dictionary+=/usr/share/dict/words
 	" or you can specify dictionary path using sourceParams 
 	" ('dictPaths' must be list of files)


### PR DESCRIPTION
The feature helps us define new variables in `camelCase`, `snake_case`, and so on.
The feature only makes sense with `isVolatile` set to `true` in its `sourceOptions`.
For performance, `items` are only refreshed at word boundary.

In addition, the documentations are updated.